### PR TITLE
Move CLI logic back into distributed.cli

### DIFF
--- a/distributed/cli/dask_remote.py
+++ b/distributed/cli/dask_remote.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, division, absolute_import
+
+import click
 from tornado.ioloop import IOLoop
 
 from distributed.cli.utils import check_python_3
-from distributed.submit.remote_cli import remote
+from distributed.submit.remote_cli import _remote
 
 import signal
 
@@ -15,9 +17,17 @@ signal.signal(signal.SIGINT, handle_signal)
 signal.signal(signal.SIGTERM, handle_signal)
 
 
+@click.command()
+@click.option('--host', type=str, default=None,
+              help="IP or hostname of this server")
+@click.option('--port', type=int, default=8788, help="Remote Client Port")
+def main(host, port):
+    _remote(host, port)
+
+
 def go():
     check_python_3()
-    remote()
+    main()
 
 
 if __name__ == '__main__':

--- a/distributed/cli/dask_submit.py
+++ b/distributed/cli/dask_submit.py
@@ -1,6 +1,9 @@
+import click
+
+from tornado import gen
 from tornado.ioloop import IOLoop
 from distributed.cli.utils import check_python_3
-from distributed.submit.submit_cli import submit
+from distributed.submit.submit_cli import _submit
 
 import signal
 
@@ -13,9 +16,20 @@ signal.signal(signal.SIGINT, handle_signal)
 signal.signal(signal.SIGTERM, handle_signal)
 
 
+@click.command()
+@click.argument('remote_client_address', type=str, required=True)
+@click.argument('filepath', type=str, required=True)
+def main(remote_client_address, filepath):
+    @gen.coroutine
+    def f():
+        yield _submit(remote_client_address, filepath)
+
+    IOLoop.instance().run_sync(f)
+
+
 def go():
     check_python_3()
-    submit()
+    main()
 
 
 if __name__ == '__main__':

--- a/distributed/submit/remote_cli.py
+++ b/distributed/submit/remote_cli.py
@@ -1,23 +1,12 @@
 import socket
 import logging
 
-import click
-
 from tornado.ioloop import IOLoop
 from distributed.submit.remote_client import RemoteClient
 
 from distributed.utils import get_ip
 
 logger = logging.getLogger('distributed.remote')
-
-
-@click.command()
-@click.option('--host', type=str, default=None,
-              help="IP or hostname of this server")
-@click.option('--port', type=int, default=8788, help="Remote Client Port")
-def remote(host, port):
-    _remote(host, port)
-
 
 
 def _remote(host, port, loop=IOLoop.current(), client=RemoteClient):

--- a/distributed/submit/submit_cli.py
+++ b/distributed/submit/submit_cli.py
@@ -1,8 +1,6 @@
 import os
 import sys
-import click
 from tornado import gen
-from tornado.ioloop import IOLoop
 from distributed import rpc
 
 
@@ -18,14 +16,3 @@ def _submit(remote_client_address, filepath):
         sys.stdout.write(str(result['stdout']))
     if result['stderr']:
         sys.stderr.write(str(result['stderr']))
-
-
-@click.command()
-@click.argument('remote_client_address', type=str, required=True)
-@click.argument('filepath', type=str, required=True)
-def submit(remote_client_address, filepath):
-    @gen.coroutine
-    def f():
-        yield _submit(remote_client_address, filepath)
-
-    IOLoop.instance().run_sync(f)

--- a/distributed/submit/tests/test_remote_cli.py
+++ b/distributed/submit/tests/test_remote_cli.py
@@ -1,16 +1,8 @@
 from mock import Mock
-from click.testing import CliRunner
+
 from tornado.ioloop import IOLoop
-
-from distributed.submit.remote_cli import remote, _remote
 from distributed.submit.remote_client import RemoteClient
-
-
-def test_dask_remote():
-    runner = CliRunner()
-    result = runner.invoke(remote, ['--help'])
-    assert '--host TEXT     IP or hostname of this server' in result.output
-    assert result.exit_code == 0
+from distributed.submit.remote_cli import _remote
 
 
 def test_cli_runs_remote_client():

--- a/distributed/submit/tests/test_submit_cli.py
+++ b/distributed/submit/tests/test_submit_cli.py
@@ -2,17 +2,20 @@ from __future__ import print_function, division, absolute_import
 from click.testing import CliRunner
 from tornado import gen
 from distributed.submit.remote_client import RemoteClient
-from distributed.submit.submit_cli import _submit, submit
-from distributed.utils_test import valid_python_script, invalid_python_script, current_loop
+from distributed.submit.submit_cli import _submit
+from distributed.utils_test import valid_python_script, invalid_python_script,\
+    current_loop
 
 
-def test_dask_submit_cli_writes_result_to_stdout(capsys, current_loop, tmpdir, valid_python_script):
+def test_dask_submit_cli_writes_result_to_stdout(capsys, current_loop, tmpdir,
+                                                 valid_python_script):
     @gen.coroutine
     def test():
         remote_client = RemoteClient(ip='127.0.0.1', local_dir=str(tmpdir))
         yield remote_client._start()
 
-        yield _submit('127.0.0.1:{0}'.format(remote_client.port), str(valid_python_script))
+        yield _submit('127.0.0.1:{0}'.format(remote_client.port),
+                      str(valid_python_script))
         out, err = capsys.readouterr()
         assert 'hello world!' in out
         yield remote_client._close()
@@ -20,22 +23,17 @@ def test_dask_submit_cli_writes_result_to_stdout(capsys, current_loop, tmpdir, v
     current_loop.run_sync(test, timeout=5)
 
 
-def test_dask_submit_cli_writes_traceback_to_stdout(capsys, current_loop, tmpdir, invalid_python_script):
+def test_dask_submit_cli_writes_traceback_to_stdout(capsys, current_loop, tmpdir,
+                                                    invalid_python_script):
     @gen.coroutine
     def test():
         remote_client = RemoteClient(ip='127.0.0.1', local_dir=str(tmpdir))
         yield remote_client._start()
 
-        yield _submit('127.0.0.1:{0}'.format(remote_client.port), str(invalid_python_script))
+        yield _submit('127.0.0.1:{0}'.format(remote_client.port),
+                      str(invalid_python_script))
         out, err = capsys.readouterr()
         assert 'Traceback' in err
         yield remote_client._close()
 
     current_loop.run_sync(test, timeout=5)
-
-
-def test_submit_runs_as_a_cli():
-    runner = CliRunner()
-    result = runner.invoke(submit, ['--help'])
-    assert result.exit_code == 0
-    assert 'Usage: submit [OPTIONS] REMOTE_CLIENT_ADDRESS FILEPATH' in result.output


### PR DESCRIPTION
Addresses [comments](https://github.com/dask/distributed/pull/360#discussion_r73141465) on the original PR -- simplifies the organization of the CLI logic. 

@mrocklin, is this what you meant? If so I'll continue with the other code reorganization you suggested once I understand this code better.
